### PR TITLE
Patch Automatic cleaning of HTML + Rails 3.1 asset path update

### DIFF
--- a/lib/generators/markdownizer/install_generator.rb
+++ b/lib/generators/markdownizer/install_generator.rb
@@ -8,7 +8,7 @@ module Markdownizer
       source_root File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
 
       def copy_stylesheet_file
-        copy_file 'coderay.css', 'public/stylesheets/markdownizer.css'
+        copy_file 'coderay.css', 'app/assets/stylesheets/markdownizer.css'
       end
     end
   end

--- a/lib/markdownizer.rb
+++ b/lib/markdownizer.rb
@@ -74,6 +74,7 @@
 # [cr]: http://github.com/rubychan/coderay
 require 'rdiscount'
 require 'coderay'
+require 'sanitize'
 require 'active_record' unless defined?(ActiveRecord)
 
 module Markdownizer
@@ -193,10 +194,11 @@ module Markdownizer
       # Markdownized html every time the model is saved.
       self.before_save :"render_#{attribute}"
 
-      # Define the converter method, which will assign the rendered html to the
-      # `:rendered_attribute` field.
+      # Define the converter method, which will first remove any html from the
+      # attribute and then assign the rendered html to the `:rendered_attribute`
+      # field.
       define_method :"render_#{attribute}" do
-        self.send(:"rendered_#{attribute}=", Markdownizer.markdown(Markdownizer.coderay(self.send(attribute), options), hierarchy))
+        self.send(:"rendered_#{attribute}=", Markdownizer.markdown(Markdownizer.coderay(Sanitize.clean(self.send(attribute)), options), hierarchy))
       end
     end
   end

--- a/markdownizer.gemspec
+++ b/markdownizer.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '>= 3.0.3'
   s.add_runtime_dependency 'rdiscount'
   s.add_runtime_dependency 'coderay'
+  s.add_runtime_dependency 'sanitize'
 
   s.add_development_dependency 'rocco'
   s.add_development_dependency 'git'


### PR DESCRIPTION
I have patched Sanitize support into markdownizer to automatically strip existing html when `markdownizer!` is called. It however still leaves the initial HTML in the original `attribute` field, however as long as this is shown without html_safe then this should not cause any issues.

I have also Updated the path the generator installs the stylesheet into to reflect the asset location in Rails 3.1 as they have moved from `public/stylesheets` into `app/assets/stylesheets`
