### PR TITLE
Use Github fenced code blocks in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ gem 'markdownizer'
 
 If you want code highlighting, you should run this generator too:
 
-```ruby
+```
 rails generate markdownizer:install
 ```
 


### PR DESCRIPTION
Hey! Would be nice to have syntax highlighting in the code examples in your readme. I converted your codeblocks to Github's fenced syntax and added highlighting for ruby.
